### PR TITLE
Add support for OIDC Well-Known Configuration Endpoints

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -1,12 +1,9 @@
 import OauthClient from '@resonant/oauth-client';
 
-const oauthClient = new OauthClient(
-  new URL('http://localhost:8000/oauth/'),
-  'Qir0Aq7AKIsAkMDLQe9MEfORbHEBKsViNhAKJf1A',
-  {
-    scopes: ['openid'],
-  },
-);
+// Will be initialized asynchronously in the DOMContentLoaded event
+// TODO: should we have a seperate example app for initializing using
+// well-known URL?
+let oauthClient;
 
 function updateDom() {
   document.querySelector('#sign-in-link').style.visibility = oauthClient.isLoggedIn
@@ -31,6 +28,11 @@ document.querySelector('#sign-out-link').addEventListener('click', async (event)
 });
 
 document.addEventListener('DOMContentLoaded', async () => {
+  oauthClient = await OauthClient.fromWellKnownUrl(
+    new URL('http://localhost:8000/oauth/'),
+    'Qir0Aq7AKIsAkMDLQe9MEfORbHEBKsViNhAKJf1A',
+    ['openid'],
+  );
   updateDom();
   await oauthClient.maybeRestoreLogin();
   updateDom();

--- a/example/index.js
+++ b/example/index.js
@@ -3,6 +3,9 @@ import OauthClient from '@resonant/oauth-client';
 const oauthClient = new OauthClient(
   new URL('http://localhost:8000/oauth/'),
   'Qir0Aq7AKIsAkMDLQe9MEfORbHEBKsViNhAKJf1A',
+  {
+    scopes: ['openid'],
+  },
 );
 
 function updateDom() {

--- a/src/oauth-client.ts
+++ b/src/oauth-client.ts
@@ -7,7 +7,7 @@ import OauthFacade, {
 export type Headers = Record<string, string>;
 
 export type OauthClientOptions = {
-  scopes?: string[];
+  scopes: string[];
   redirectUrl?: URL;
 };
 
@@ -19,7 +19,7 @@ export default class OauthClient {
   constructor(
     authorizationServerBaseUrl: URL,
     protected readonly clientId: string,
-    { scopes = [], redirectUrl = OauthClient.cleanedCurrentUrl() }: OauthClientOptions = {},
+    { scopes, redirectUrl = OauthClient.cleanedCurrentUrl() }: OauthClientOptions,
   ) {
     if (!window.isSecureContext) {
       throw new Error('OAuth Client cannot operate within insecure contexts.');

--- a/src/oauth-client.ts
+++ b/src/oauth-client.ts
@@ -1,3 +1,4 @@
+import type { AuthorizationServiceConfigurationJson } from '@openid/appauth';
 import OauthFacade, {
   NoAuthInProgressError,
   TokenResponse,
@@ -6,39 +7,58 @@ import OauthFacade, {
 
 export type Headers = Record<string, string>;
 
-export type OauthClientOptions = {
-  scopes: string[];
-  redirectUrl?: URL;
-};
-
 export default class OauthClient {
   protected token: TokenResponse | null = null;
 
   protected readonly oauthFacade: OauthFacade;
 
   constructor(
-    authorizationServerBaseUrl: URL,
+    protected readonly authorizationEndpoint: URL,
+    protected readonly tokenEndpoint: URL,
+    protected readonly revocationEndpoint: URL,
     protected readonly clientId: string,
-    { scopes, redirectUrl = OauthClient.cleanedCurrentUrl() }: OauthClientOptions,
+    protected readonly scopes: string[],
+    protected readonly redirectUrl: URL = OauthClient.cleanedCurrentUrl(),
   ) {
     if (!window.isSecureContext) {
       throw new Error('OAuth Client cannot operate within insecure contexts.');
     }
-
-    const cleanedAuthorizationServerBaseUrl = new URL(authorizationServerBaseUrl);
-    // A URL base cannot have query string or fragment components
-    cleanedAuthorizationServerBaseUrl.search = '';
-    cleanedAuthorizationServerBaseUrl.hash = '';
 
     // RFC6749 3.1.2 requires that the Redirection URI must not include a fragment component
     const cleanedRedirectUrl = new URL(redirectUrl);
     cleanedRedirectUrl.hash = '';
 
     this.oauthFacade = new OauthFacade(
-      cleanedAuthorizationServerBaseUrl,
+      this.authorizationEndpoint,
+      this.tokenEndpoint,
+      this.revocationEndpoint,
       cleanedRedirectUrl,
       this.clientId,
+      this.scopes,
+    );
+  }
+
+  public static async fromWellKnownUrl(
+    authorizationServerBaseUrl: URL, // TODO: maybe require the entire well-known URL
+    clientId: string,
+    scopes: string[],
+    redirectUrl: URL = OauthClient.cleanedCurrentUrl(),
+  ): Promise<OauthClient> {
+    const wellKnownConfigUrl = new URL(
+      '.well-known/openid-configuration',
+      authorizationServerBaseUrl.href,
+    );
+
+    const response = await fetch(wellKnownConfigUrl);
+    const urls: AuthorizationServiceConfigurationJson = await response.json();
+
+    return new OauthClient(
+      new URL(urls.authorization_endpoint, authorizationServerBaseUrl),
+      new URL(urls.token_endpoint, authorizationServerBaseUrl),
+      new URL(urls.revocation_endpoint, authorizationServerBaseUrl),
+      clientId,
       scopes,
+      redirectUrl,
     );
   }
 

--- a/src/oauth-facade/index.ts
+++ b/src/oauth-facade/index.ts
@@ -44,13 +44,17 @@ export default class OauthFacade {
   /**
    * Create an OauthFacade.
    *
-   * @param authorizationServerBaseUrl The common base URL for Authorization Server endpoints.
+   * @param authorizationEndpoint The URL of the Authorization Server's authorization endpoint.
+   * @param tokenEndpoint The URL of the Authorization Server's token endpoint.
+   * @param revocationEndpoint The URL of the Authorization Server's token revocation endpoint.
    * @param redirectUrl The URL of the current page, to be redirected back to after authorization.
    * @param clientId The Client ID for this application.
    * @param scopes An array of scopes to request access to.
    */
   constructor(
-    protected readonly authorizationServerBaseUrl: URL,
+    protected readonly authorizationEndpoint: URL,
+    protected readonly tokenEndpoint: URL,
+    protected readonly revocationEndpoint: URL,
     protected readonly redirectUrl: URL,
     protected readonly clientId: string,
     protected readonly scopes: string[],
@@ -60,18 +64,6 @@ export default class OauthFacade {
       token_endpoint: this.tokenEndpoint.toString(),
       revocation_endpoint: this.revocationEndpoint.toString(),
     });
-  }
-
-  protected get authorizationEndpoint(): URL {
-    return new URL('authorize/', this.authorizationServerBaseUrl);
-  }
-
-  protected get tokenEndpoint(): URL {
-    return new URL('token/', this.authorizationServerBaseUrl);
-  }
-
-  protected get revocationEndpoint(): URL {
-    return new URL('revoke_token/', this.authorizationServerBaseUrl);
   }
 
   /**

--- a/tests/http-server.ts
+++ b/tests/http-server.ts
@@ -45,6 +45,22 @@ function oauthResponseToMsw(oauthResponse: OAuth2Server.Response): HttpResponse<
 export default setupServer(
   // Define a route for the test URL, so navigations to load it don't trigger unknown route errors
   http.get('http://www.example.com/', () => new HttpResponse()),
+
+  http.get('https://api.example.com/.well-known/openid-configuration', () => {
+    return HttpResponse.json({
+      authorization_endpoint: 'https://api.example.com/authorize/',
+      device_authorization_endpoint: 'https://api.example.com/oauth/identity/o/api/device/code',
+      revocation_endpoint: 'https://api.example.com/revoke_token/',
+      token_endpoint: 'https://api.example.com/token/',
+      userinfo_endpoint: 'https://api.example.com/oauth/identity/o/api/userinfo',
+      jwks_uri: 'https://api.example.com/oauth/.well-known/jwks.json',
+      issuer: 'https://api.example.com',
+      response_types_supported: ['code'],
+      subject_types_supported: ['public'],
+      id_token_signing_alg_values_supported: ['RS256'],
+    });
+  }),
+
   http.get('https://api.example.com/authorize/', async ({ request }) => {
     const oauthRequest = await mswRequestToOauth(request);
     const oauthResponse = new OAuth2Server.Response();

--- a/tests/oauth-client.test.ts
+++ b/tests/oauth-client.test.ts
@@ -1,5 +1,5 @@
 import { beforeAll, beforeEach, describe, expect, onTestFinished, test, vi } from 'vitest';
-import { AuthorizationFailureError, TokenFailureError } from '../src/index.js';
+import OAuthClient, { AuthorizationFailureError, TokenFailureError } from '../src/index.js';
 import { model as oauth2Model } from './oauth2.js';
 import { buildClient } from './setup-client.js';
 
@@ -79,6 +79,47 @@ describe('not logged in', () => {
     window.location.assign(resp.headers.get('Location')!);
     // Re-create the client, as this would happen after the redirect
     client = buildClient();
+
+    // Test token exchange after inbound redirect
+    await client.maybeRestoreLogin();
+
+    expect(client.isLoggedIn).toEqual(true);
+    expect(client.authHeaders).toHaveProperty('Authorization');
+  });
+
+  test('full login flow using well-known URL', async () => {
+    let client = await OAuthClient.fromWellKnownUrl(
+      new URL('https://api.example.com'),
+      'resonant-client-id',
+      ['read', 'write'],
+    );
+
+    // Test outbound redirect to authorization
+    await client.redirectToLogin();
+    await vi.waitUntil(() => new URL(window.location.href).hostname === 'api.example.com');
+
+    expect(window.localStorage.length).toEqual(3);
+    expect(window.localStorage.getItem('appauth_current_authorization_request')).not.toBeNull();
+    const redirectUrl = new URL(window.location.href);
+    expect(redirectUrl.hostname).toEqual('api.example.com');
+    expect(redirectUrl.pathname).toEqual('/authorize/');
+    expect(redirectUrl.searchParams.has('client_id')).toEqual(true);
+    expect(redirectUrl.searchParams.has('code_challenge')).toEqual(true);
+    expect(redirectUrl.searchParams.get('code_challenge_method')).toEqual('S256');
+
+    // Execute inbound redirect from authorization
+    const resp = await fetch(redirectUrl, { method: 'GET', redirect: 'manual' });
+
+    expect(resp.status).toEqual(302);
+    // biome-ignore lint/style/noNonNullAssertion: an error from assigning null is fine in a test
+    window.location.assign(resp.headers.get('Location')!);
+
+    // Re-create the client, as this would happen after the redirect
+    client = await OAuthClient.fromWellKnownUrl(
+      new URL('https://api.example.com'),
+      'resonant-client-id',
+      ['read', 'write'],
+    );
 
     // Test token exchange after inbound redirect
     await client.maybeRestoreLogin();

--- a/tests/setup-client.ts
+++ b/tests/setup-client.ts
@@ -17,7 +17,13 @@ declare module 'vitest' {
 }
 
 export function buildClient(scopes: string[] = []): OAuthClient {
-  return new OAuthClient(new URL('https://api.example.com'), 'resonant-client-id', { scopes });
+  return new OAuthClient(
+    new URL('https://api.example.com/authorize/'),
+    new URL('https://api.example.com/token/'),
+    new URL('https://api.example.com/revoke_token/'),
+    'resonant-client-id',
+    scopes,
+  );
 }
 
 beforeEach((context) => {


### PR DESCRIPTION
Currently, `resonant-oauth-client` is hardcoded to the exact endpoint structure of `django-oauth-toolkit`. However, the OAuth2 spec is more flexible and allows for different endpoint structures, which means this client will not work with other OAuth2-compliant servers such as the new [`django-allauth` idp module](https://docs.allauth.org/en/latest/idp/openid-connect/introduction.html).

This PR adds support for the OIDC Well-Known Configuration Endpoint, which allows the client to discover the correct endpoints dynamically. This is a more robust solution that can work with any OIDC-compliant server that implements the well-known configuration endpoint spec, not just those that follow the `django-oauth-toolkit` conventions. 
Note that the well-known endpoint is specifically a part of the **OIDC** spec, not **OAuth2**. Furthermore, it is not a required part of the core OIDC spec. Therefore, I've ensured this change does not break compatibility with servers that do not implement it; in that case, the client will fall back to the hardcoded endpoints.