### PR TITLE
Run `biome migrate --write`

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.5/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.0.6/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
@@ -33,7 +33,10 @@
         "useAsConstAssertion": "on",
         "useDefaultParameterLast": "on",
         "useNumberNamespace": "on",
-        "useSingleVarDeclarator": "on"
+        "useSingleVarDeclarator": "on",
+        "useEnumInitializers": "error",
+        "useSelfClosingElements": "error",
+        "noUselessElse": "error"
       }
     }
   },


### PR DESCRIPTION
Currently, running `npm run format` results in this warning ([example from `master` CI](https://github.com/kitware-resonant/resonant-oauth-client/actions/runs/16256283659/job/45893104653#step:6:10)) -

```
$ npm run format

> @resonant/oauth-client@0.0.0 format
> biome check --write

biome.jsonc:2:14 deserialize ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

  ⚠ The configuration schema version does not match the CLI version 2.0.6
  
    1 │ {
  > 2 │   "$schema": "https://biomejs.dev/schemas/2.0.5/schema.json",
      │              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    3 │   "vcs": {
    4 │     "enabled": true,
  
  ℹ   Expected:                     2.0.6
      Found:                        2.0.5
  
  
  ℹ Run the command biome migrate to migrate the configuration file.
  

Checked 21 files in 262ms. No fixes applied.
Found 1 warning.
```

It seems that the current version of `biome.jsonc` is not supported by the version of the biome CLI that is installed. Running `npx biome migrate --write` generates a new config file for biome, which I have committed here on this branch. 