### PR TITLE
Make `biome` fail on warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,11 +17,11 @@
     "/dist/"
   ],
   "scripts": {
-    "test:lint": "biome check",
+    "test:lint": "biome check --error-on-warnings",
     "test:type": "tsc --project ./tests",
     "test:unit": "vitest --watch=false",
     "test": "npm-run-all test:*",
-    "format": "biome check --write",
+    "format": "biome check --write --error-on-warnings",
     "watch": "tsc --watch",
     "build:clean": "rimraf ./dist",
     "build:compile": "tsc",


### PR DESCRIPTION
Currently, warnings are logged to `stderr` but do not affect the exit code. Passing `--error-on-warnings` causes all warnings to be classified as errors.