### PR TITLE
Deny msw install scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,5 +43,8 @@
   },
   "engines": {
     "node": ">=16"
+  },
+  "allowScripts": {
+    "msw": false
   }
 }


### PR DESCRIPTION
npm 12 blocks dependency install scripts by default and warns on every `npm ci` about msw's blocked postinstall:

```
npm warn install-scripts 1 package had install scripts blocked because they are not covered by allowScripts:
npm warn install-scripts   msw@2.15.0 (postinstall: node -e "import('./config/scripts/postinstall.js').catch(() => void 0)")
```

That postinstall only re-copies `mockServiceWorker.js` when the project has an `msw.workerDirectory` field in `package.json` (see https://mswjs.io/docs/recipes/custom-worker-script-location/). This project has no such field and uses msw only via `msw/node` in tests, so the script is a no-op here.

This records an explicit denial with `npm install-scripts deny msw`, which silences the warning permanently (a name-only denial survives msw upgrades).
