### PR TITLE
Write HTML5 doctype in lowercase

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8">


### PR DESCRIPTION
Biome 2.5.7 changed the HTML formatter to write the HTML5 doctype in lowercase. This unblocks the `test` check on #162.